### PR TITLE
Add key to allow SSH-ing into an ECS instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,6 +89,7 @@ resource "aws_launch_configuration" "main" {
   image_id                    = var.image_id
   associate_public_ip_address = false
   security_groups             = concat(var.security_group_ids, [aws_security_group.main.id])
+  key_name                    = var.key_name
 
   root_block_device {
     volume_type = "standard"

--- a/variables.tf
+++ b/variables.tf
@@ -63,3 +63,8 @@ variable "ebs_volume_size" {
   type        = number
   default     = 50
 }
+
+variable "key_name" {
+  description = "Keypair to allow SSH access to ASG instances"
+  type        = string
+}


### PR DESCRIPTION
When attempting to test https://github.com/onemedical/terraform-modules/pull/198 , I realized the instances provisioned by the launch configuration/ASG don't use a keypair, preventing us from SSH-ing into the instance. For testing purposes, we will want the capability to ssh into the instances in the ECS cluster. This change will likely be reverted once we have a working deploy